### PR TITLE
Merge: feature-start-stop-scripts into development for v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ coverage.xml
 # kthx
 GITHUB_PAT
 GITHUB_PAC
+
+# exclude the self hosted sauces
+*-sauce.tar.gz
+# and the work_dir_tmp
+work_dir_tmp/**/*


### PR DESCRIPTION
Merge: feature-start-stop-scripts into development for v1.0.0

Opened for tracking 🔍 

Almost made oopsie & merged into master... That would have slipped past my branch protections! (fixed PR, taking notes...)

**_We are the only one blocking https://github.com/catspeed-cc/sd-webui-forge-docker/pull/2 from merge development->master for v1.0.0_**