### PR TITLE
Merge: `fix-image-size` into `development`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# The only line that ever gets cached is next
-FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+# OLD and LARGE ubuntu image
+#FROM nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+# NEW and small ubuntu image
+FROM nvidia/cuda:12.9.1-base-ubuntu22.04
 
 # we do not want interactive anything
 ENV DEBIAN_FRONTEND=noninteractive
@@ -12,11 +14,16 @@ ARG DUMMY=
 
 # Install system deps
 RUN apt-get update && apt-get install -y \
-    python3 git wget nano curl htop libgl1 libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
+    python3 git wget nano curl htop gcc g++ libgl1 libglib2.0-0 && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Upgrade system jeez
-RUN apt-get upgrade -y && apt-get dist-upgrade -y
+RUN apt-get upgrade -y && apt-get dist-upgrade -y && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Download and install the latest pip directly using get-pip.py
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
@@ -100,6 +107,9 @@ RUN cd /app/webui/repositories/BLIP && \
 #assets_commit_hash = os.environ.get('ASSETS_COMMIT_HASH', "6f7db241d2f8ba7457bac5ca9753331f0c266917")
 #huggingface_guess_commit_hash = os.environ.get('', "84826248b49bb7ca754c73293299c4d4e23a548d")
 #blip_commit_hash = os.environ.get('BLIP_COMMIT_HASH', "48211a1594f1321b00f14c9f7a5b4813144b2fb9")
+
+# Ensure APT cache is cleaned! (image size concerns)
+RUN apt autoremove -y && apt clean && rm -rf /var/lib/apt/lists/*   
 
 #
 ## Startup SD WebUI Forge


### PR DESCRIPTION
We have a new task! Yippee 😸 

# Cut fucking image size down bro
- [x] Switch to `nvidia/cuda:12.9.1-base-ubuntu22.04`
- [x] Confirm compile, fix dependency issues with `apt install`
- [ ] Try to make a common venv for all dependencies within the project (using Dockerfile)
- [ ] Any other tasks which can help reduce image sizes (while we have the branch open)
- [ ] Verify compilation and lack of errors. Fix errors.
- [ ] Build , Push dockerhub images (push v1.1.0 tag then push latest tag last!, they will list at the top)
- [ ] `README.md` updates for v1.1.0 (pre-empt prep for v1.1.0)
- [ ] Merge `fix-image-size` into `development`

Yes I have too much fun ;D